### PR TITLE
Beginning of travis configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: trusty
 language: python
 python:
   - "2.7"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,17 @@
+language: python
+python:
+  - "2.7"
+  - "3.5"
+  - "3.6"
+  - "3.6-dev"
+  - "3.7-dev"
+before_install:
+  - echo "deb http://deb.torproject.org/torproject.org $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/tor.list
+  - gpg --keyserver keys.gnupg.net --recv A3C4F0F979CAA22CDBA8F512EE8CBC9E886DDD89
+  - gpg --export A3C4F0F979CAA22CDBA8F512EE8CBC9E886DDD89 | sudo apt-key add -
+  - sudo apt-get -qq update
+  - sudo apt-get -y install tor deb.torproject.org-keyring
+install:
+  - pip install .
+  - pip install -r requirements.txt
+script: python ./run_tests.py -a

--- a/setup.py
+++ b/setup.py
@@ -75,6 +75,7 @@ global-exclude *.swp
 global-exclude *.swo
 global-exclude .tox
 global-exclude *~
+global-exclude .travis.yml
 recursive-exclude test/data *
 recursive-exclude docs/_build *
 """.strip()

--- a/test/integ/installation.py
+++ b/test/integ/installation.py
@@ -128,7 +128,7 @@ class TestInstallation(unittest.TestCase):
       issues = []
 
       for path in git_contents:
-        if path not in tar_contents and path not in ['.gitignore']:
+        if path not in tar_contents and path not in ['.gitignore', '.travis.yml']:
           issues.append('  * %s is missing from our release tarball' % path)
 
       for path in tar_contents:


### PR DESCRIPTION
Install tor Ubuntu package and provision dependencies before running the
run_tests.py script with -a for all tests including integration against
a running tor daemon.